### PR TITLE
Let users choose x-axis for skyline charts

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -122,32 +122,62 @@ def run_model(meta_params_dict, adjustment):
 
     # make dataset for bokeh plots
     ivar = crunch.ivar
-    wages = ivar[9] + ivar[10]
-    wages = int(wages)
+    _, mtr_opt, _ = crunch.taxsim_inputs()
     df = pd.concat([ivar] * 5000, ignore_index=True)
     increments = pd.DataFrame(list(range(0, 500000, 100)))
-    zeros = pd.DataFrame([0] * 5000)
-    # ivar position of e00200p
-    df[9] = increments
-    # set spouse earning to zero
-    df[10] = zeros
+
+    # use Calculation Option to determine what var to increment
+    if mtr_opt == 'Taxpayer Earnings':
+        span = int(ivar[9])
+        df[9] = increments
+    elif mtr_opt == 'Spouse Earnings':
+        span = int(ivar[10])
+        df[10] = increments
+    elif mtr_opt == 'Short Term Gains':
+        span = int(ivar[13])
+        df[13] = increments
+    elif mtr_opt == 'Long Term Gains':
+        span = int(ivar[14])
+        df[14] = increments
+    elif mtr_opt == 'Qualified Dividends':
+        span = int(ivar[14])
+        df[11] = increments
+    elif mtr_opt == 'Interest Received':
+        span = int(ivar[12])
+        df[12] = increments
+    elif mtr_opt == 'Pensions':
+        span = int(ivar[17])
+        df[17] = increments
+    elif mtr_opt == 'Gross Social Security Benefits':
+        span = int(ivar[18])
+        df[18] = increments
+    elif mtr_opt == 'Real Estate Taxes Paid':
+        span = int(ivar[20])
+        df[20] = increments
+    elif mtr_opt == 'Mortgage':
+        span = int(ivar[23])
+        df[23] = increments    
+
     b = Batch(df)
     df_base = b.create_table()
     df_reform = b.create_table(policy_mods)
+
     # compute average tax rates
     df_base['IATR'] = df_base['Individual Income Tax'] / df_base['AGI']
     df_base['PATR'] = df_base['Payroll Tax'] / df_base['AGI']
     df_reform['IATR'] = df_reform['Individual Income Tax'] / df_reform['AGI']
     df_reform['PATR'] = df_reform['Payroll Tax'] / df_reform['AGI']
+    df_base['Axis'] = increments
+    df_reform['Axis'] = increments
 
-    return comp_output(crunch, df_base, df_reform, wages)
+    return comp_output(crunch, df_base, df_reform, span, mtr_opt)
 
 
-def comp_output(crunch, df_base, df_reform, wages):
+def comp_output(crunch, df_base, df_reform, span, mtr_opt):
 
-    liabilities = liability_plot(df_base, df_reform, wages)
-    rates = rate_plot(df_base, df_reform, wages)
-    credits = credit_plot(df_base, df_reform, wages)
+    liabilities = liability_plot(df_base, df_reform, span, mtr_opt)
+    rates = rate_plot(df_base, df_reform, span, mtr_opt)
+    credits = credit_plot(df_base, df_reform, span, mtr_opt)
 
     basic = crunch.basic_table()
     detail = crunch.calc_table()

--- a/cs-config/cs_config/outputs.py
+++ b/cs-config/cs_config/outputs.py
@@ -5,7 +5,7 @@ from bokeh.plotting import figure
 from bokeh.models import ColumnDataSource, CustomJS, Toggle, NumeralTickFormatter, LinearAxis, Range1d, Span, Label
 
 
-def liability_plot(df_base, df_reform, wages):
+def liability_plot(df_base, df_reform, span, mtr_opt):
     df_base = ColumnDataSource(df_base)
     df_reform = ColumnDataSource(df_reform)
     tools = "pan, zoom_in, zoom_out, reset"
@@ -14,23 +14,23 @@ def liability_plot(df_base, df_reform, wages):
     fig.yaxis.axis_label = "Tax Liabilities"
     fig.yaxis.formatter = NumeralTickFormatter(format="$0,000")
 
-    filer_income = Span(location=wages, dimension='height', line_color='black', line_dash='dotted', line_width=1.5)
+    filer_income = Span(location=span, dimension='height', line_color='black', line_dash='dotted', line_width=1.5)
     fig.add_layout(filer_income)
-    label_format = f'{wages:,}'
-    filer_income_label = Label(x=wages, y=25, y_units='screen', x_offset=10, text="Household Wages: $" + label_format,
+    label_format = f'{span:,}'
+    filer_income_label = Label(x=span, y=25, y_units='screen', x_offset=10, text="{}: $".format(mtr_opt) + label_format,
                            text_color='#303030', text_font="arial", text_font_style="italic", text_font_size = "10pt")
     fig.add_layout(filer_income_label)
     axis = Span(location=0, dimension='width', line_color='#bfbfbf', line_width=1.5)
     fig.add_layout(axis)
 
-    iitax_base = fig.line(x="Wages", y="Individual Income Tax", line_color='#2b83ba', muted_color='#2b83ba',
+    iitax_base = fig.line(x="Axis", y="Individual Income Tax", line_color='#2b83ba', muted_color='#2b83ba',
                           line_width=2, legend="Individual Income Tax Liability", muted_alpha=0.1, source=df_base)
-    payroll_base = fig.line(x="Wages", y="Payroll Tax", line_color='#abdda4', muted_color='#abdda4',
+    payroll_base = fig.line(x="Axis", y="Payroll Tax", line_color='#abdda4', muted_color='#abdda4',
                             line_width=2, legend='Payroll Tax Liability', muted_alpha=0.1, source=df_base)
 
-    iitax_reform = fig.line(x="Wages", y="Individual Income Tax", line_color='#2b83ba', muted_color='#2b83ba',
+    iitax_reform = fig.line(x="Axis", y="Individual Income Tax", line_color='#2b83ba', muted_color='#2b83ba',
                             line_width=2, line_dash='dashed', legend="Individual Income Tax Liability", muted_alpha=0.1, source=df_reform)
-    payroll_reform = fig.line(x="Wages", y="Payroll Tax", line_color='#abdda4', muted_color='#abdda4',
+    payroll_reform = fig.line(x="Axis", y="Payroll Tax", line_color='#abdda4', muted_color='#abdda4',
                               line_width=2, line_dash='dashed', legend='Payroll Tax Liability', muted_alpha=0.1, source=df_reform)
 
     iitax_base.muted = False
@@ -55,7 +55,7 @@ def liability_plot(df_base, df_reform, wages):
                             "object2": payroll_reform}
 
     fig.xaxis.formatter = NumeralTickFormatter(format="$0,000")
-    fig.xaxis.axis_label = "Household Wages"
+    fig.xaxis.axis_label = mtr_opt
     fig.xaxis.minor_tick_line_color = None
 
     fig.legend.click_policy = "mute"
@@ -66,7 +66,7 @@ def liability_plot(df_base, df_reform, wages):
 
     outputs = {
         "media_type": "bokeh",
-        "title": "Tax Liabilities by Wage (Holding Other Inputs Constant)",
+        "title": "Tax Liabilities by {} (Holding Other Inputs Constant)".format(mtr_opt),
         "data": {
             "javascript": js_liability,
             "html": div_liability
@@ -76,7 +76,7 @@ def liability_plot(df_base, df_reform, wages):
     return outputs
 
 
-def rate_plot(df_base, df_reform, wages):
+def rate_plot(df_base, df_reform, span, mtr_opt):
     df_base = ColumnDataSource(df_base)
     df_reform = ColumnDataSource(df_reform)
     tools = "pan, zoom_in, zoom_out, reset"
@@ -85,31 +85,31 @@ def rate_plot(df_base, df_reform, wages):
     fig.yaxis.axis_label = "Tax Rate"
     fig.yaxis.formatter = NumeralTickFormatter(format="0%")
     
-    filer_income = Span(location=wages, dimension='height', line_color='black', line_dash='dotted', line_width=1.5)
+    filer_income = Span(location=span, dimension='height', line_color='black', line_dash='dotted', line_width=1.5)
     fig.add_layout(filer_income)
-    label_format = f'{wages:,}'
-    filer_income_label = Label(x=wages, y=25, y_units='screen', x_offset=10, text="Household Wages: $" + label_format, 
+    label_format = f'{span:,}'
+    filer_income_label = Label(x=span, y=25, y_units='screen', x_offset=10, text="{}: $".format(mtr_opt) + label_format, 
                                 text_color='#303030', text_font="arial", text_font_style="italic", text_font_size = "10pt")
     fig.add_layout(filer_income_label)
     axis = Span(location=0, dimension='width', line_color='#bfbfbf', line_width=1.5)
     fig.add_layout(axis)
     
-    iitax_atr_base = fig.line(x="Wages", y="IATR", line_color='#2b83ba', muted_color='#2b83ba',
+    iitax_atr_base = fig.line(x="Axis", y="IATR", line_color='#2b83ba', muted_color='#2b83ba',
                               line_width=2, legend="Income Tax Average Rate", muted_alpha=0.1, source=df_base)
-    payroll_atr_base = fig.line(x="Wages", y="PATR", line_color='#abdda4', muted_color='#abdda4',
+    payroll_atr_base = fig.line(x="Axis", y="PATR", line_color='#abdda4', muted_color='#abdda4',
                                 line_width=2, legend='Payroll Tax Average Rate', muted_alpha=0.1, source=df_base)
-    iitax_mtr_base = fig.line(x="Wages", y="Income Tax MTR", line_color='#fdae61', muted_color='#fdae61',
+    iitax_mtr_base = fig.line(x="Axis", y="Income Tax MTR", line_color='#fdae61', muted_color='#fdae61',
                               line_width=2, legend="Income Tax Marginal Rate", muted_alpha=0.1, source=df_base)
-    payroll_mtr_base = fig.line(x="Wages", y="Payroll Tax MTR", line_color='#d7191c', muted_color='#d7191c',
+    payroll_mtr_base = fig.line(x="Axis", y="Payroll Tax MTR", line_color='#d7191c', muted_color='#d7191c',
                                 line_width=2, legend='Payroll Tax Marginal Rate', muted_alpha=0.1, source=df_base)
 
-    iitax_atr_reform = fig.line(x="Wages", y="IATR", line_color='#2b83ba', muted_color='#2b83ba', line_width=2,
+    iitax_atr_reform = fig.line(x="Axis", y="IATR", line_color='#2b83ba', muted_color='#2b83ba', line_width=2,
                                 line_dash='dashed', legend="Income Tax Average Rate", muted_alpha=0.1, source=df_reform)
-    payroll_atr_reform = fig.line(x="Wages", y="PATR", line_color='#abdda4', muted_color='#abdda4', line_width=2,
+    payroll_atr_reform = fig.line(x="Axis", y="PATR", line_color='#abdda4', muted_color='#abdda4', line_width=2,
                                   line_dash='dashed', legend='Payroll Tax Average Rate', muted_alpha=0.1, source=df_reform)
-    iitax_mtr_reform = fig.line(x="Wages", y="Income Tax MTR", line_color='#fdae61', muted_color='#fdae61',
+    iitax_mtr_reform = fig.line(x="Axis", y="Income Tax MTR", line_color='#fdae61', muted_color='#fdae61',
                                 line_width=2, line_dash='dashed', legend="Income Tax Marginal Rate", muted_alpha=0.1, source=df_reform)
-    payroll_mtr_reform = fig.line(x="Wages", y="Payroll Tax MTR", line_color='#d7191c', muted_color='#d7191c',
+    payroll_mtr_reform = fig.line(x="Axis", y="Payroll Tax MTR", line_color='#d7191c', muted_color='#d7191c',
                                   line_width=2, line_dash='dashed', legend='Payroll Tax Marginal Rate', muted_alpha=0.1, source=df_reform)
 
     iitax_atr_base.muted = False
@@ -142,7 +142,7 @@ def rate_plot(df_base, df_reform, wages):
                             "object4": payroll_mtr_reform}
 
     fig.xaxis.formatter = NumeralTickFormatter(format="$0,000")
-    fig.xaxis.axis_label = "Household Wages"
+    fig.xaxis.axis_label = mtr_opt
     fig.xaxis.minor_tick_line_color = None
 
     fig.legend.click_policy = "mute"
@@ -153,7 +153,7 @@ def rate_plot(df_base, df_reform, wages):
 
     outputs = {
         "media_type": "bokeh",
-        "title": "Tax Rates by Wage (Holding Other Inputs Constant)",
+        "title": "Tax Rates by {} (Holding Other Inputs Constant)".format(mtr_opt),
         "data": {
             "javascript": js_rate,
             "html": div_rate
@@ -163,38 +163,38 @@ def rate_plot(df_base, df_reform, wages):
     return outputs
 
 
-def credit_plot(df_base, df_reform, wages):
+def credit_plot(df_base, df_reform, span, mtr_opt):
     df_base = ColumnDataSource(df_base)
     df_reform = ColumnDataSource(df_reform)
     tools = "pan, zoom_in, zoom_out, reset"
     fig = figure(plot_width=600, plot_height=500, x_range=(
         -2500, 70000), tools=tools, active_drag="pan")
 
-    filer_income = Span(location=wages, dimension='height', line_color='black', line_dash='dotted', line_width=1.5)
+    filer_income = Span(location=span, dimension='height', line_color='black', line_dash='dotted', line_width=1.5)
     fig.add_layout(filer_income)
-    label_format = f'{wages:,}'
-    filer_income_label = Label(x=wages, y=45, y_units='screen', x_offset=10, text="Household Wages: $" + label_format,
+    label_format = f'{span:,}'
+    filer_income_label = Label(x=span, y=45, y_units='screen', x_offset=10, text="{}: $".format(mtr_opt) + label_format,
                                 text_color='#303030', text_font="arial", text_font_style="italic", text_font_size = "10pt")
     fig.add_layout(filer_income_label)
     axis = Span(location=0, dimension='width', line_color='#bfbfbf', line_width=1.5)
     fig.add_layout(axis)
 
-    eitc_base = fig.line(x="Wages", y="EITC", line_color='#2b83ba', muted_color='#2b83ba',
+    eitc_base = fig.line(x="Axis", y="EITC", line_color='#2b83ba', muted_color='#2b83ba',
                          line_width=2, legend="Earned Income Tax Credit", muted_alpha=0.1, source=df_base)
-    ctc_base = fig.line(x="Wages", y="CTC", line_color='#abdda4', muted_color='#abdda4',
+    ctc_base = fig.line(x="Axis", y="CTC", line_color='#abdda4', muted_color='#abdda4',
                         line_width=2, legend='Nonrefundable Child Tax Credit', muted_alpha=0.1, source=df_base)
-    ctc_refund_base = fig.line(x="Wages", y="CTC Refundable", line_color='#fdae61', muted_color='#fdae61',
+    ctc_refund_base = fig.line(x="Axis", y="CTC Refundable", line_color='#fdae61', muted_color='#fdae61',
                                line_width=2, legend='Refundable Child Tax Credit', muted_alpha=0.1, source=df_base)
-    cdcc_base = fig.line(x="Wages", y="Child care credit", line_color='#d7191c', muted_color='#d7191c',
+    cdcc_base = fig.line(x="Axis", y="Child care credit", line_color='#d7191c', muted_color='#d7191c',
                          line_width=2, legend='Child and Dependent Care Credit', muted_alpha=0.1, source=df_base)
 
-    eitc_reform = fig.line(x="Wages", y="EITC", line_color='#2b83ba', muted_color='#2b83ba', line_width=2,
+    eitc_reform = fig.line(x="Axis", y="EITC", line_color='#2b83ba', muted_color='#2b83ba', line_width=2,
                            line_dash='dashed', legend="Earned Income Tax Credit", muted_alpha=0.1, source=df_reform)
-    ctc_reform = fig.line(x="Wages", y="CTC", line_color='#abdda4', muted_color='#abdda4', line_width=2,
+    ctc_reform = fig.line(x="Axis", y="CTC", line_color='#abdda4', muted_color='#abdda4', line_width=2,
                           line_dash='dashed', legend='Nonrefundable Child Tax Credit', muted_alpha=0.1, source=df_reform)
-    ctc_refund_reform = fig.line(x="Wages", y="CTC Refundable", line_color='#fdae61', muted_color='#fdae61',
+    ctc_refund_reform = fig.line(x="Axis", y="CTC Refundable", line_color='#fdae61', muted_color='#fdae61',
                                  line_width=2, line_dash='dashed', legend='Refundable Child Tax Credit', muted_alpha=0.1, source=df_reform)
-    cdcc_reform = fig.line(x="Wages", y="Child care credit", line_color='#d7191c', muted_color='#d7191c', line_width=2,
+    cdcc_reform = fig.line(x="Axis", y="Child care credit", line_color='#d7191c', muted_color='#d7191c', line_width=2,
                            line_dash='dashed', legend='Child and Dependent Care Credit', muted_alpha=0.1, source=df_reform)
 
     ctc_base.muted = True
@@ -227,7 +227,7 @@ def credit_plot(df_base, df_reform, wages):
     fig.yaxis.formatter = NumeralTickFormatter(format="$0,000")
     fig.yaxis.axis_label = "Tax Credits"
     fig.xaxis.formatter = NumeralTickFormatter(format="$0,000")
-    fig.xaxis.axis_label = "Household Wages"
+    fig.xaxis.axis_label = mtr_opt
     fig.xaxis.minor_tick_line_color = None
 
     fig.legend.click_policy = "mute"
@@ -238,7 +238,7 @@ def credit_plot(df_base, df_reform, wages):
 
     outputs = {
         "media_type": "bokeh",
-        "title": "Tax Credits by Wage (Holding Other Inputs Constant)",
+        "title": "Tax Credits by {} (Holding Other Inputs Constant)".format(mtr_opt),
         "data": {
             "javascript": js_credit,
             "html": div_credit

--- a/taxcrunch/cruncher.py
+++ b/taxcrunch/cruncher.py
@@ -425,35 +425,32 @@ class Cruncher:
         Returns:
             self.df_mtr: a Pandas dataframe MTR results with respect to 'mtr_options'
         """
-        if self.mtr_options != "Don't Bother":
 
-            mtr_calc = self.calc1.mtr(calc_all_already_called=True
-                                      )
-            self.mtr_df = pd.DataFrame(
-                data=[mtr_calc[1], mtr_calc[0]],
-                index=["Income Tax Marginal Rate",
-                       "Payroll Tax Marginal Rate"],
-            )
+        mtr_calc = self.calc1.mtr(calc_all_already_called=True
+                                  )
+        self.mtr_df = pd.DataFrame(
+            data=[mtr_calc[1], mtr_calc[0]],
+            index=["Income Tax Marginal Rate",
+                   "Payroll Tax Marginal Rate"],
+        )
 
-            mtr_calc_reform = self.calc_reform.mtr(calc_all_already_called=True
-                                                   )
-            mtr_df_reform = pd.DataFrame(
-                data=[mtr_calc_reform[1], mtr_calc_reform[0]],
-                index=["Income Tax Marginal Rate",
-                       "Payroll Tax Marginal Rate"],
-            )
+        mtr_calc_reform = self.calc_reform.mtr(calc_all_already_called=True
+                                               )
+        mtr_df_reform = pd.DataFrame(
+            data=[mtr_calc_reform[1], mtr_calc_reform[0]],
+            index=["Income Tax Marginal Rate",
+                   "Payroll Tax Marginal Rate"],
+        )
 
-            self.df_mtr = pd.concat([self.mtr_df, mtr_df_reform], axis=1)
-            self.df_mtr.columns = ["Base", "Reform"]
+        self.df_mtr = pd.concat([self.mtr_df, mtr_df_reform], axis=1)
+        self.df_mtr.columns = ["Base", "Reform"]
 
-            self.df_mtr["Change"] = self.df_mtr["Reform"] - self.df_mtr["Base"]
+        self.df_mtr["Change"] = self.df_mtr["Reform"] - self.df_mtr["Base"]
 
-            self.df_mtr = self.df_mtr.round(3)
+        self.df_mtr = self.df_mtr.round(3)
 
-            return self.df_mtr
+        return self.df_mtr
 
-        else:
-            pass
 
     def basic_table(self):
         """
@@ -520,15 +517,10 @@ class Cruncher:
 
         df_calc_mtr = self.calc_mtr.dataframe(calculation).transpose()
 
-        if self.mtr_options == "Don't Bother":
-            self.df_calc = pd.concat([df_calc1, df_calc2], axis=1)
-            self.df_calc.columns = ["Base", "Reform"]
-            self.df_calc.index = labels
-        else:
-            self.df_calc = pd.concat([df_calc1, df_calc2, df_calc_mtr], axis=1)
-            self.df_calc.columns = ["Base", "Reform",
-                                    "+ $1 ({})".format(self.mtr_options)]
-            self.df_calc.index = labels
+        self.df_calc = pd.concat([df_calc1, df_calc2, df_calc_mtr], axis=1)
+        self.df_calc.columns = ["Base", "Reform",
+                                "+ $1 ({})".format(self.mtr_options)]
+        self.df_calc.index = labels
 
         self.df_calc = self.df_calc.round(2)
 

--- a/taxcrunch/cruncher.py
+++ b/taxcrunch/cruncher.py
@@ -197,7 +197,7 @@ class Cruncher:
         num_deps = ivar.loc[:, 5]
         mars = np.where(mstat == 1, np.where(num_deps > 0, 4, 1), 2)
         assert np.all(np.logical_or(mars == 1,
-                                np.logical_or(mars == 2, mars == 4)))
+                                    np.logical_or(mars == 2, mars == 4)))
         self.invar["MARS"] = mars
         self.invar["f2441"] = ivar.loc[:, 6]
         self.invar["n24"] = ivar.loc[:, 7]
@@ -268,8 +268,6 @@ class Cruncher:
         elif self.mtr_options == "Mortgage":
             self.ivar2.loc[:, 23] = self.ivar2.loc[:, 23] + 1
             return self.ivar2, "e19200"
-        elif self.mtr_options == "Don't Bother":
-            return self.ivar2, "None"
 
     def choose_baseline(self):
         """
@@ -305,7 +303,8 @@ class Cruncher:
                     baseline_file = self.baseline
                     baseline_url = REFORMS_URL + baseline_file
                     self.pol = tc.Policy()
-                    self.pol.implement_reform(tc.Policy.read_json_reform(baseline_url))
+                    self.pol.implement_reform(
+                        tc.Policy.read_json_reform(baseline_url))
                 except:
                     print("Baseline file does not exist")
 
@@ -338,7 +337,8 @@ class Cruncher:
                 reform_filename = os.path.join(
                     CURRENT_PATH, self.custom_reform)
                 self.pol2 = tc.Policy()
-                self.pol2.implement_reform(tc.Policy.read_json_reform(reform_filename))
+                self.pol2.implement_reform(
+                    tc.Policy.read_json_reform(reform_filename))
             except:
                 print("Reform file path does not exist")
         # then as dictionary
@@ -408,7 +408,8 @@ class Cruncher:
 
         self.basic_vals = pd.concat([basic_vals1, basic_vals2], axis=1)
         self.basic_vals.columns = ["Base", "Reform"]
-        self.basic_vals.index = ["Individual Income Tax", "Employee + Employer Payroll Tax"]
+        self.basic_vals.index = [
+            "Individual Income Tax", "Employee + Employer Payroll Tax"]
 
         self.basic_vals["Change"] = self.basic_vals[
             "Reform"] - self.basic_vals["Base"]
@@ -430,14 +431,16 @@ class Cruncher:
                                       )
             self.mtr_df = pd.DataFrame(
                 data=[mtr_calc[1], mtr_calc[0]],
-                index=["Income Tax Marginal Rate", "Payroll Tax Marginal Rate"],
+                index=["Income Tax Marginal Rate",
+                       "Payroll Tax Marginal Rate"],
             )
 
             mtr_calc_reform = self.calc_reform.mtr(calc_all_already_called=True
                                                    )
             mtr_df_reform = pd.DataFrame(
                 data=[mtr_calc_reform[1], mtr_calc_reform[0]],
-                index=["Income Tax Marginal Rate", "Payroll Tax Marginal Rate"],
+                index=["Income Tax Marginal Rate",
+                       "Payroll Tax Marginal Rate"],
             )
 
             self.df_mtr = pd.concat([self.mtr_df, mtr_df_reform], axis=1)
@@ -523,7 +526,8 @@ class Cruncher:
             self.df_calc.index = labels
         else:
             self.df_calc = pd.concat([df_calc1, df_calc2, df_calc_mtr], axis=1)
-            self.df_calc.columns = ["Base", "Reform", "+ $1"]
+            self.df_calc.columns = ["Base", "Reform",
+                                    "+ $1 ({})".format(self.mtr_options)]
             self.df_calc.index = labels
 
         self.df_calc = self.df_calc.round(2)

--- a/taxcrunch/defaults.json
+++ b/taxcrunch/defaults.json
@@ -463,8 +463,7 @@
                     "Pensions",
                     "Gross Social Security Beneifts",
                     "Real Estate Taxes Paid",
-                    "Mortgage",
-                    "Don't Bother"
+                    "Mortgage"
                 ]
             }
         }

--- a/taxcrunch/defaults.json
+++ b/taxcrunch/defaults.json
@@ -441,8 +441,8 @@
         }
     },
     "mtr_options": {
-        "title": "Options for marginal tax rate calculation",
-        "description": "Adds $1 to chosen field for analysis on how liabilities change.",
+        "title": "Options for skyline chart analysis",
+        "description": "Skyline charts will be created by incrementing this measure.",
         "section_1": "Calculation Options",
         "notes": "",
         "type": "str",

--- a/taxcrunch/tests/expected_calc_table.csv
+++ b/taxcrunch/tests/expected_calc_table.csv
@@ -1,4 +1,4 @@
-,Base,Reform,+ $1
+,Base,Reform,+ $1 (Taxpayer Earnings)
 Adjusted Gross Income (AGI),100000.0,100000.0,100001.0
 Unemployment Insurance in AGI,0.0,0.0,0.0
 Social Security in AGI,0.0,0.0,0.0

--- a/taxcrunch/tests/test_cruncher.py
+++ b/taxcrunch/tests/test_cruncher.py
@@ -40,7 +40,7 @@ def test_calc_table():
     c = create_data()
     table = c.calc_table()
     assert isinstance(table, pd.DataFrame)
-    assert table.iloc[0]["Reform"] + 1 == table.iloc[0]["+ $1"]
+    assert table.iloc[0]["Reform"] + 1 == table.iloc[0]["+ $1 (Taxpayer Earnings)"]
     # table.to_csv("expected_calc_table.csv")
     expected_table = pd.read_csv(
         os.path.join(CURR_PATH, "expected_calc_table.csv"), index_col=0


### PR DESCRIPTION
This PR makes it such that the x-axis on the Compute Studio skyline charts is determined by user input for the parameter called "Options for skyline chart analysis." The default remains primary taxpayer earnings.

In addition, the "+ $1" column in Compute Studio's "Calculation of Liabilities" will now be called "+ $1 {INCOME_TYPE}" to make column easier to interpret.

Thanks @MattHJensen for the idea. 