### PR TITLE
Add pip dependency to environment.yml

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -14,5 +14,6 @@ dependencies:
 - dask
 - bokeh
 - markdown
+- pip
 - pip:
   - cs-kit


### PR DESCRIPTION
This avoids this build warning:
>Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.