### PR TITLE
Change name of cs-config package in setup.py

### DIFF
--- a/cs-config/setup.py
+++ b/cs-config/setup.py
@@ -9,9 +9,9 @@ import setuptools
 import os
 
 setuptools.setup(
-    name="compconfig",
-    description="COMP configuration files.",
-    url="https://github.com/comp-org/COMP-Developer-Toolkit",
+    name="cs-config",
+    description="Compute Studio configuration files.",
+    url="https://github.com/compute-studio/compute-studio-kit",
     packages=setuptools.find_packages(),
     include_package_data=True,
 )


### PR DESCRIPTION
@Peter-Metz I noticed the package name didn't get updated. I got some complaints from pip (but it still seems to work):

```
Collecting cs-config from git+https://github.com/PSLmodels/Tax-Cruncher.git@master#egg=cs-config&subdirectory=cs-config
  Cloning https://github.com/PSLmodels/Tax-Cruncher.git (to revision master) to /tmp/pip-install-2qpsha5b/cs-config
  Running command git clone -q https://github.com/PSLmodels/Tax-Cruncher.git /tmp/pip-install-2qpsha5b/cs-config
  WARNING: Generating metadata for package cs-config produced metadata for project name compconfig. Fix your #egg=cs-config fragments.
Building wheels for collected packages: compconfig, compconfig
  Building wheel for compconfig (setup.py): started
  Building wheel for compconfig (setup.py): finished with status 'done'
  Created wheel for compconfig: filename=compconfig-0.0.0-cp37-none-any.whl size=8328 sha256=fc9aee221ca6e9dc5236db12a123f514a76acdb5ffc659446b1e27b84e0b43d9
  Stored in directory: /tmp/pip-ephem-wheel-cache-shc8eg15/wheels/79/e9/23/9a5e715927f5b73b01e5fe1e920509a1973ee48a7f017754d7
  Building wheel for compconfig (setup.py): started
  Building wheel for compconfig (setup.py): finished with status 'error'
  ERROR: Command errored out with exit status 1:
   command: /opt/conda/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-2qpsha5b/compconfig/setup.py'"'"'; __file__='"'"'/tmp/pip-install-2qpsha5b/compconfig/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' bdist_wheel -d /tmp/pip-wheel-dx1ufkru --python-tag cp37
       cwd: /tmp/pip-install-2qpsha5b/compconfig/
  Complete output (5 lines):
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/opt/conda/lib/python3.7/tokenize.py", line 447, in open
      buffer = _builtin_open(filename, 'rb')
  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-2qpsha5b/compconfig/setup.py'
  ----------------------------------------
  ERROR: Failed building wheel for compconfig
  Running setup.py clean for compconfig
  ERROR: Command errored out with exit status 1:
   command: /opt/conda/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"'"'/tmp/pip-install-2qpsha5b/compconfig/setup.py'"'"'; __file__='"'"'/tmp/pip-install-2qpsha5b/compconfig/setup.py'"'"';f=getattr(tokenize, '"'"'open'"'"', open)(__file__);code=f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' clean --all
       cwd: /tmp/pip-install-2qpsha5b/compconfig
  Complete output (5 lines):
  Traceback (most recent call last):
    File "<string>", line 1, in <module>
    File "/opt/conda/lib/python3.7/tokenize.py", line 447, in open
      buffer = _builtin_open(filename, 'rb')
  FileNotFoundError: [Errno 2] No such file or directory: '/tmp/pip-install-2qpsha5b/compconfig/setup.py'
  ----------------------------------------
  ERROR: Failed cleaning build dir for compconfig
Successfully built compconfig
Failed to build compconfig
Installing collected packages: compconfig
Successfully installed compconfig-0.0.0
```