### PR TITLE
taxcrunch package now available on conda!

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ b.create_table('REFORM_FILE_PATH')
 
 How to install Tax-Cruncher
 -------------
+Install with conda:
+```
+conda install -c pslmodels taxcrunch
+```
+
 Install from source:
 
 ```


### PR DESCRIPTION
To install:

```
conda install -c pslmodels taxcrunch
```

Note: the test failures do not affect usage and will be resolved when Tax-Calc 3.0 is released.