### PR TITLE
Add ability to specify output variables

### DIFF
--- a/taxcrunch/tests/test_multi_cruncher.py
+++ b/taxcrunch/tests/test_multi_cruncher.py
@@ -13,12 +13,11 @@ input_path = os.path.join(CURRENT_PATH, "example_test_input.csv")
 reform_path = os.path.join(CURRENT_PATH, "test_reform.json")
 b = mcr.Batch(input_path)
 
-reform_dict = {
-    "CTC_c": {2013: 1300, 2018: 1800}
-    }
+reform_dict = {"CTC_c": {2013: 1300, 2018: 1800}}
+
 
 def test_read_input(crunch=b):
-    
+
     invar, invar_marg, rows = b.read_input()
     assert isinstance(invar, pd.DataFrame)
     assert isinstance(rows, int)
@@ -26,36 +25,39 @@ def test_read_input(crunch=b):
     # check that number of input rows matches output rows
     assert rows == len(b.create_table().index)
 
+
 def test_get_pol_directory_file(crunch=b):
 
-    n = b.get_pol(reform_file=reform_path) 
-    assert n._CTC_c[2018-2013] == 1000
+    n = b.get_pol(reform_file=reform_path)
+    assert n._CTC_c[2018 - 2013] == 1000
+
 
 def test_get_pol_dict(crunch=b):
-    
+
     m = b.get_pol(reform_file=reform_dict)
-    assert m._CTC_c[2018-2013] == 1800
+    assert m._CTC_c[2018 - 2013] == 1800
+
 
 def test_get_pol_link(crunch=b):
-    
+
     reform_preset = "Trump2016.json"
     m = b.get_pol(reform_file=reform_preset)
-    assert m._II_rt1[2017-2013] == 0.12
+    assert m._II_rt1[2017 - 2013] == 0.12
 
-CURR_PATH = os.path.abspath(os.path.dirname(__file__))
 
 def test_calc_table(crunch=b):
-    
+
     table = b.create_table()
     assert isinstance(table, pd.DataFrame)
-    table_path = os.path.join(CURR_PATH, "expected_multi_table.csv")
+    table_path = os.path.join(CURRENT_PATH, "expected_multi_table.csv")
     # table.to_csv(table_path)
     expected_table = pd.read_csv(table_path, index_col=0)
     for col in table.columns:
         assert np.allclose(table[col], expected_table[col])
 
+
 def test_create_table_behresp_args(crunch=b):
-    
+
     table = b.create_table(reform_file=reform_dict, be_sub=0.25)
     assert isinstance(table, pd.DataFrame)
 
@@ -67,10 +69,11 @@ def test_create_table_behresp_args(crunch=b):
     with pytest.raises(AssertionError):
         b.create_table(be_sub=0.25)
 
+
 def test_diff_tables(crunch=b):
 
     table = b.create_diff_table(reform_file=reform_dict)
-    assert isinstance(table,pd.DataFrame)
+    assert isinstance(table, pd.DataFrame)
 
     # can only specify response if there is a reform
     with pytest.raises(AssertionError):
@@ -78,7 +81,28 @@ def test_diff_tables(crunch=b):
 
     # baseline must be current law if response
     with pytest.raises(AssertionError):
-        b.create_diff_table(reform_file="Trump2016.json", baseline=reform_dict, be_sub=0.25)
+        b.create_diff_table(
+            reform_file="Trump2016.json", baseline=reform_dict, be_sub=0.25
+        )
+
+
+def test_custom_output_cols(crunch=b):
+
+    custom_vars = ["iitax", "payrolltax"]
+    custom_labels = ["II Tax", "Payroll Tax"]
+
+    table = b.create_table(
+        tc_vars=custom_vars, tc_labels=custom_labels, include_mtr=False
+    )
+    assert isinstance(table, pd.DataFrame)
+    assert len(table.columns) == 2
+
+    with pytest.raises(AssertionError):
+        b.create_table(tc_vars=custom_vars, include_mtr=False)
+
+    with pytest.raises(AttributeError):
+        b.create_table(tc_vars=["fake_var1", "fake_var2"], tc_labels=custom_labels)
+
 
 def test_qbid_params():
     """
@@ -92,4 +116,4 @@ def test_qbid_params():
     # QBID from TPC paper
     expect_qbid = [15000, 1612.5, 0, 15000, 10750, 10000]
 
-    assert np.allclose(table['Qualified Business Income Deduction'], expect_qbid)
+    assert np.allclose(table["Qualified Business Income Deduction"], expect_qbid)


### PR DESCRIPTION
This PR gives users the ability to specify their own output variables when producing tables with the `Batch` class. This can be especially useful when analyzing large input files to reduce the size of the resulting dataframe.

Also, this PR drops the functions for writing tables to csv since I think they were unnecessary.