### PR TITLE
Add Python 3.8 to Travis and remove extraneous line in multi_cruncher.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: python
 python:
   - "3.6"
   - "3.7"
+  - "3.8"
 
 before_install:
   - "pip install -U pip"

--- a/taxcrunch/__init__.py
+++ b/taxcrunch/__init__.py
@@ -2,4 +2,4 @@ from taxcrunch.cruncher import *
 from taxcrunch.multi_cruncher import *
 
 name = "taxcrunch"
-__version__ = "0.4.2"
+__version__ = "0.4.3"

--- a/taxcrunch/multi_cruncher.py
+++ b/taxcrunch/multi_cruncher.py
@@ -46,7 +46,6 @@ class Batch:
     def __init__(self, path):
         self.path = path
         self.invar, self.invar_marg, self.rows = self.read_input()
-        self.mtr = self.calc_mtr(reform_file=None)
 
         self.TC_VARS = [
             "RECID",
@@ -180,6 +179,7 @@ class Batch:
             adjust_ratios=None,
         )
 
+        # if tc_vars and tc_labels are not specified, defaults are used
         if tc_vars is None:
             tc_vars = self.TC_VARS
         if tc_labels is None:
@@ -188,6 +188,7 @@ class Batch:
         assert len(tc_vars) > 0
         assert len(tc_vars) == len(tc_labels)
 
+        # if no reform file is passed, table will show current law values
         if reform_file is None:
             pol = tc.Policy()
             assert be_sub == be_inc == be_cg == 0
@@ -195,6 +196,7 @@ class Batch:
             calc.advance_to_year(year)
             calc.calc_all()
             calcs = calc.dataframe(tc_vars)
+        # if a reform file is passed, table will show reform values
         else:
             pol = self.get_pol(reform_file)
             calc = tc.Calculator(policy=pol, records=recs)
@@ -204,6 +206,7 @@ class Batch:
             _, df2br = br.response(calc_base, calc, response_elasticities, dump=True)
             calcs = df2br[tc_vars]
 
+        # if include_mtr is True, the tables includes three columns with MTRs
         if include_mtr:
             mtr = self.calc_mtr(reform_file)
             mtr_df = pd.DataFrame(data=mtr).transpose()

--- a/taxcrunch/tests/test_multi_cruncher.py
+++ b/taxcrunch/tests/test_multi_cruncher.py
@@ -104,6 +104,16 @@ def test_custom_output_cols(crunch=b):
         b.create_table(tc_vars=["fake_var1", "fake_var2"], tc_labels=custom_labels)
 
 
+def test_mtr_cols(crunch=b):
+
+    mtr_cols = ["Payroll Tax MTR", "Income Tax MTR", "Combined MTR"]
+    table = b.create_table()
+    assert set(mtr_cols).issubset(table.columns)
+
+    table_no_mtr = b.create_table(include_mtr=False)
+    assert set(mtr_cols).issubset(table_no_mtr.columns) is False
+
+
 def test_qbid_params():
     """
     Adpots a test from Tax-Calculator that checks QBID calculations against


### PR DESCRIPTION
Notably, this PR removes an extraneous line in `multi_cruncher.py`, which was creating an extra `Calculator` object and presumably causing a slowdown.