### PR TITLE
Modifications to MTR calculations

### DIFF
--- a/taxcrunch/cruncher.py
+++ b/taxcrunch/cruncher.py
@@ -379,13 +379,17 @@ class Cruncher:
             self.df_mtr: a Pandas dataframe MTR results with respect to 'mtr_options'
         """
 
-        mtr_calc = self.calc1.mtr(calc_all_already_called=True)
+        mtr_calc = self.calc1.mtr(
+            calc_all_already_called=True, wrt_full_compensation=False
+        )
         self.mtr_df = pd.DataFrame(
             data=[mtr_calc[1], mtr_calc[0]],
             index=["Income Tax Marginal Rate", "Payroll Tax Marginal Rate"],
         )
 
-        mtr_calc_reform = self.calc_reform.mtr(calc_all_already_called=True)
+        mtr_calc_reform = self.calc_reform.mtr(
+            calc_all_already_called=True, wrt_full_compensation=False
+        )
         mtr_df_reform = pd.DataFrame(
             data=[mtr_calc_reform[1], mtr_calc_reform[0]],
             index=["Income Tax Marginal Rate", "Payroll Tax Marginal Rate"],

--- a/taxcrunch/cruncher.py
+++ b/taxcrunch/cruncher.py
@@ -393,10 +393,10 @@ class Cruncher:
 
         self.df_mtr = pd.concat([self.mtr_df, mtr_df_reform], axis=1)
         self.df_mtr.columns = ["Base", "Reform"]
+        # convert decimals to percents
+        self.df_mtr = self.df_mtr * 100
 
         self.df_mtr["Change"] = self.df_mtr["Reform"] - self.df_mtr["Base"]
-
-        self.df_mtr = self.df_mtr.round(3)
 
         return self.df_mtr
 

--- a/taxcrunch/tests/test_taxsim.py
+++ b/taxcrunch/tests/test_taxsim.py
@@ -15,5 +15,8 @@ def test_a18_validation():
     taxsim_out = os.path.join(CURRENT_PATH, "taxsim_validation/taxsim_out_a18.csv")
     taxsim_df = pd.read_csv(taxsim_out)
 
-    assert np.allclose(table_a18["Individual Income Tax"], taxsim_df["fiitax"], atol=1)
-    assert np.allclose(table_a18["Payroll Tax"], taxsim_df["fica"], atol=1)
+    taxcrunch_frate = table_a18["Income Tax MTR"]*100
+
+    assert np.allclose(table_a18["Individual Income Tax"], taxsim_df["fiitax"], atol=0.01)
+    assert np.allclose(table_a18["Payroll Tax"], taxsim_df["fica"], atol=0.01)
+    assert np.allclose(taxcrunch_frate, taxsim_df["frate"], atol=0.01)


### PR DESCRIPTION
This PR makes two modification to Tax-Cruncher MTR calculations:
- Excludes employer FICA taxes in MTR calculation. Tax-Cruncher MTR's displayed on the web app are now aligned definitionally with TAXSIM and with Tax-Cruncher `Batch` mode
- Converts decimals to percentages on web app. Allows for easier reading and more decimals places. (Requested in #45) 

cc @MattHJensen 