### PR TITLE
Add variables to output table on web app

### DIFF
--- a/taxcrunch/cruncher.py
+++ b/taxcrunch/cruncher.py
@@ -434,8 +434,11 @@ class Cruncher:
             "c00100",
             "e02300",
             "c02500",
+            "standard",
             "c04470",
+            "qbided",
             "c04800",
+            "taxbc",
             "c07220",
             "c11070",
             "c07180",
@@ -444,23 +447,26 @@ class Cruncher:
             "c09600",
             "niit",
             "c05800",
-            "qbided",
+            "payrolltax"
         ]
         labels = [
             "Adjusted Gross Income (AGI)",
             "Unemployment Insurance in AGI",
             "Social Security in AGI",
+            "Standard Deduction (Zero for Itemizers)",
             "Itemized Deductions",
+            "Qualified Business Income Deduction",
             "Taxable Income",
+            "Regular Tax Before Credits",
             "Child Tax Credit (CTC)",
             "CTC Refundable",
             "Child Care Credit",
-            "Earned Income Tax Credit (EITC)",
+            "Earned Income Tax Credit",
             "Alternative Minimum Tax (AMT) Taxable Income",
             "AMT Liability",
             "Net Investment Income Tax",
-            "Income Tax Before Credits",
-            "Qualified Business Income Deduction",
+            "Income Tax Before Credits (Regular + AMT)",
+            "Payroll Tax (Employee + Employer)"
         ]
 
         df_calc1 = self.calc1.dataframe(calculation).transpose()

--- a/taxcrunch/tests/expected_calc_table.csv
+++ b/taxcrunch/tests/expected_calc_table.csv
@@ -2,14 +2,17 @@
 Adjusted Gross Income (AGI),100000.0,100000.0,100001.0
 Unemployment Insurance in AGI,0.0,0.0,0.0
 Social Security in AGI,0.0,0.0,0.0
+Standard Deduction (Zero for Itemizers),12200.0,6644.15,6644.15
 Itemized Deductions,0.0,0.0,0.0
+Qualified Business Income Deduction,0.0,0.0,0.0
 Taxable Income,87800.0,89118.24,89119.24
+Regular Tax Before Credits,15246.5,17820.92,17821.17
 Child Tax Credit (CTC),0.0,0.0,0.0
 CTC Refundable,0.0,0.0,0.0
 Child Care Credit,0.0,0.0,0.0
-Earned Income Tax Credit (EITC),0.0,0.0,0.0
+Earned Income Tax Credit,0.0,0.0,0.0
 Alternative Minimum Tax (AMT) Taxable Income,100000.0,100000.0,100001.0
 AMT Liability,0.0,0.0,0.0
 Net Investment Income Tax,0.0,0.0,0.0
-Income Tax Before Credits,15246.5,17820.92,17821.17
-Qualified Business Income Deduction,0.0,0.0,0.0
+Income Tax Before Credits (Regular + AMT),15246.5,17820.92,17821.17
+Payroll Tax (Employee + Employer),15300.0,15300.0,15300.15


### PR DESCRIPTION
This PR adds variables (i.e. standard deduction amount, regular tax amount, FICA) to the "Calculation of Liabilities" table on Compute Studio and shuffles the ordering for easier interpretation. Here is the (unformatted) new table:

![Screen Shot 2020-10-14 at 8 51 26 AM](https://user-images.githubusercontent.com/43755005/95991260-8fc57680-0dfa-11eb-8515-7de6763c1639.png)

cc @MattHJensen 
  