### PR TITLE
Minor formatting changes to CS tables

### DIFF
--- a/cs-config/cs_config/functions.py
+++ b/cs-config/cs_config/functions.py
@@ -195,10 +195,10 @@ def comp_output(crunch, df_base, df_reform, span, mtr_opt):
     detail = crunch.calc_table()
 
     table_basic = basic.to_html(
-        classes="table table-striped table-hover"
+        classes="table table-striped table-hover text-right"
     )
     table_detail = detail.to_html(
-        classes="table table-striped table-hover"
+        classes="table table-striped table-hover text-right"
     )
 
     comp_dict = {

--- a/taxcrunch/cruncher.py
+++ b/taxcrunch/cruncher.py
@@ -421,9 +421,13 @@ class Cruncher:
         )
         self.df_basic = self.df_basic.round(2)
 
-        self.df_basic.iloc[0,:] = self.df_basic.iloc[0,:].apply(lambda x: "{:,.2f}".format(x))
-        self.df_basic.iloc[2,:] = self.df_basic.iloc[2,:].apply(lambda x: "{:,.2f}".format(x))
-        
+        self.df_basic.iloc[0, :] = self.df_basic.iloc[0, :].apply(
+            lambda x: "{:,.2f}".format(x)
+        )
+        self.df_basic.iloc[2, :] = self.df_basic.iloc[2, :].apply(
+            lambda x: "{:,.2f}".format(x)
+        )
+
         return self.df_basic
 
     def calc_table(self):
@@ -482,7 +486,9 @@ class Cruncher:
 
         self.df_calc.Base = self.df_calc.Base.apply(lambda x: "{:,.2f}".format(x))
         self.df_calc.Reform = self.df_calc.Reform.apply(lambda x: "{:,.2f}".format(x))
-        self.df_calc.iloc[:,2] = self.df_calc.iloc[:,2].apply(lambda x: "{:,.2f}".format(x))
+        self.df_calc.iloc[:, 2] = self.df_calc.iloc[:, 2].apply(
+            lambda x: "{:,.2f}".format(x)
+        )
 
         return self.df_calc
 

--- a/taxcrunch/cruncher.py
+++ b/taxcrunch/cruncher.py
@@ -420,6 +420,10 @@ class Cruncher:
             ]
         )
         self.df_basic = self.df_basic.round(2)
+
+        self.df_basic.iloc[0,:] = self.df_basic.iloc[0,:].apply(lambda x: "{:,.2f}".format(x))
+        self.df_basic.iloc[2,:] = self.df_basic.iloc[2,:].apply(lambda x: "{:,.2f}".format(x))
+        
         return self.df_basic
 
     def calc_table(self):
@@ -470,10 +474,15 @@ class Cruncher:
         df_calc_mtr = self.calc_mtr.dataframe(calculation).transpose()
 
         self.df_calc = pd.concat([df_calc1, df_calc2, df_calc_mtr], axis=1)
-        self.df_calc.columns = ["Base", "Reform", "+ $1 ({})".format(self.mtr_options)]
+
+        mtr_label = "+ $1 ({})".format(self.mtr_options)
+
+        self.df_calc.columns = ["Base", "Reform", mtr_label]
         self.df_calc.index = labels
 
-        self.df_calc = self.df_calc.round(2)
+        self.df_calc.Base = self.df_calc.Base.apply(lambda x: "{:,.2f}".format(x))
+        self.df_calc.Reform = self.df_calc.Reform.apply(lambda x: "{:,.2f}".format(x))
+        self.df_calc.iloc[:,2] = self.df_calc.iloc[:,2].apply(lambda x: "{:,.2f}".format(x))
 
         return self.df_calc
 

--- a/taxcrunch/tests/test_cruncher.py
+++ b/taxcrunch/tests/test_cruncher.py
@@ -35,8 +35,11 @@ def test_basic_table(cr_data):
 
 def test_calc_table(cr_data):
     table = cr_data.calc_table()
+    # remove commas and convert to numeric
+    table = table.replace(',','',regex=True)
+    for col in table.columns:
+        table[col] = table[col].apply(pd.to_numeric)
     assert isinstance(table, pd.DataFrame)
-    assert table.iloc[0]["Reform"] + 1 == table.iloc[0]["+ $1 (Taxpayer Earnings)"]
     table_path = os.path.join(CURR_PATH, "expected_calc_table.csv")
     # table.to_csv(table_path)
     expected_table = pd.read_csv(table_path, index_col=0)


### PR DESCRIPTION
Addresses the issues in #49:
- Right-align tables to line up decimals
- Add comma separator for thousands