### PR TITLE
Use Paramtools 'when' validator for spouse wages and age

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -8,7 +8,7 @@ dependencies:
 - behresp>=0.9.0
 - pandas>=0.23
 - numpy>=1.13
-- paramtools>=0.10.1
+- paramtools>=0.11.0
 - pytest
 - bokeh<2.0.0
 - coverage

--- a/taxcrunch/defaults.json
+++ b/taxcrunch/defaults.json
@@ -96,9 +96,21 @@
             }
         ],
         "validators": {
-            "range": {
-                "min": 0,
-                "max": 114
+            "when": {
+                "param": "mstat",
+                "is": "Joint",
+                "then": {
+                    "range": {
+                        "min": 0,
+                        "max": 114
+                    }
+                },
+                "otherwise": {
+                    "range": {
+                        "min": 0,
+                        "max": 0
+                    }
+                }
             }
         }
     },
@@ -206,9 +218,21 @@
             }
         ],
         "validators": {
-            "range": {
-                "min": 0,
-                "max": 9e+99
+            "when": {
+                "param": "mstat",
+                "is": "Joint",
+                "then": {
+                    "range": {
+                        "min": 0,
+                        "max": 9e+99
+                    }
+                },
+                "otherwise": {
+                    "range": {
+                        "min": 0,
+                        "max": 0
+                    }
+                }
             }
         }
     },

--- a/taxcrunch/defaults_batch.json
+++ b/taxcrunch/defaults_batch.json
@@ -75,9 +75,21 @@
         "number_dims": 1,
         "value": [0],
         "validators": {
-            "range": {
-                "min": 0,
-                "max": 114
+            "when": {
+                "param": "mstat",
+                "is": 2,
+                "then": {
+                    "range": {
+                        "min": 0,
+                        "max": 114
+                    }
+                },
+                "otherwise": {
+                    "range": {
+                        "min": 0,
+                        "max": 0
+                    }
+                }
             }
         }
     },
@@ -165,9 +177,21 @@
         "number_dims": 1,
         "value": [0],
         "validators": {
-            "range": {
-                "min": 0,
-                "max": 9e+99
+            "when": {
+                "param": "mstat",
+                "is": 2,
+                "then": {
+                    "range": {
+                        "min": 0,
+                        "max": 9e+99
+                    }
+                },
+                "otherwise": {
+                    "range": {
+                        "min": 0,
+                        "max": 0
+                    }
+                }
             }
         }
     },


### PR DESCRIPTION
The goal is to alert CS users that they must enter "Married" for filing status before entering spouse wages or age.

@hdoupe this is a great feature! Is there a way add a custom error message? Or will the CS user be alerted in real time that their input isn't valid?