### PR TITLE
GH action to test for proper formatting

### DIFF
--- a/.github/workflows/check_formatting.yml
+++ b/.github/workflows/check_formatting.yml
@@ -1,0 +1,15 @@
+
+name: Check Black formatting
+
+on: [push, pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+        with:
+          options: "-l 79 --check"
+          src: "."


### PR DESCRIPTION
This PR adds a second GH action to test for proper code formatting.  This repo is using the `black` code formatter with 79 character lines.